### PR TITLE
feat: use higlass-python widget impl

### DIFF
--- a/higlass_widget/widget.py
+++ b/higlass_widget/widget.py
@@ -1,9 +1,10 @@
 import json
 import pathlib
-from typing import Any, Dict
 
 import ipywidgets
 import traitlets.traitlets as t
+
+import hg.utils as utils
 
 here = pathlib.Path(__file__).parent
 
@@ -12,7 +13,16 @@ with open(here / "labextension" / "package.json") as f:
 
 version = pkg["version"]
 
+def save_b64_image_to_png(filename, b64str):
+    """Save a base64 encoded image to a file."""
+    import base64
 
+    imgdata = base64.b64decode(b64str.split(",")[1])
+    with open(filename, "wb") as f:
+        f.write(imgdata)
+
+
+@ipywidgets.register
 class HiGlassWidget(ipywidgets.DOMWidget):
     _model_name = t.Unicode("HiGlassModel").tag(sync=True)
     _model_module = t.Unicode("higlass-widget").tag(sync=True)
@@ -22,26 +32,55 @@ class HiGlassWidget(ipywidgets.DOMWidget):
     _view_module = t.Unicode("higlass-widget").tag(sync=True)
     _view_module_version = t.Unicode(version).tag(sync=True)
 
-    _viewconf = t.Unicode("null").tag(sync=True)
+    _model_data = t.List([]).tag(sync=True)
 
-    # readonly properties
-    location = t.List(t.Union([t.Float(), t.Tuple()]), read_only=True).tag(sync=True)
+    viewconf = t.Dict({}).tag(sync=True)
+    height = t.Int().tag(sync=True)
 
-    def __init__(self, viewconf: Dict[str, Any], **kwargs):
-        super().__init__(_viewconf=json.dumps(viewconf), **kwargs)
+    dom_element_id = t.Unicode(read_only=True).tag(sync=True)
 
-    def reload(self, *items):
-        msg = json.dumps(["reload", items])
-        self.send(msg)
+    # Read-only properties that get updated by HiGlass exclusively
+    location = t.List(t.Union([t.Float(), t.List()]), read_only=True).tag(sync=True)
+    cursor_location = t.List([], read_only=True).tag(sync=True)
+    selection = t.List([], read_only=True).tag(sync=True)
 
-    def zoom_to(
-        self,
-        view_id: str,
-        start1: int,
-        end1: int,
-        start2: int = None,
-        end2: int = None,
-        animate_time: int = 500,
-    ):
-        msg = json.dumps(["zoomTo", view_id, start1, end1, start2, end2, animate_time])
-        self.send(msg)
+    # Short-hand options
+    auth_token = t.Unicode().tag(sync=True)
+    bounded = t.Bool(None, allow_none=True).tag(sync=True)
+    default_track_options = t.Dict({}).tag(sync=True)
+    dark_mode = t.Bool(False).tag(sync=True)
+    renderer = t.Unicode().tag(sync=True)
+    select_mode = t.Bool(False).tag(sync=True)
+    selection_on_alt = t.Bool(False).tag(sync=True)
+
+    # For any kind of options. Note that whatever is defined in options will
+    # be overwritten by the short-hand options
+    options = t.Dict({}).tag(sync=True)
+
+    def __init__(self, viewconf, **kwargs):
+        self.on_msg(self._handle_js_events)
+        self.callbacks = {}
+        super().__init__(viewconf=viewconf, **kwargs)
+
+    def get_base64_img(self, callback):
+        uuid = utils.uid()
+
+        self.callbacks[uuid] = callback
+
+        self.send(
+            json.dumps(
+                {
+                    "request": "save_as_png",
+                    "params": {"uuid": uuid},
+                }
+            )
+        )
+
+    def _handle_js_events(self, widget, content, buffers=None):
+        try:
+            if self.callbacks[content["params"]["uuid"]]:
+                self.callbacks[content["params"]["uuid"]](content["imgData"])
+                del self.callbacks[content["params"]["uuid"]]
+        except Exception as e:
+            self.log.error(e)
+            self.log.exception("Unhandled exception while handling msg")

--- a/higlass_widget/widget.py
+++ b/higlass_widget/widget.py
@@ -4,8 +4,6 @@ import pathlib
 import ipywidgets
 import traitlets.traitlets as t
 
-import hg.utils as utils
-
 here = pathlib.Path(__file__).parent
 
 with open(here / "labextension" / "package.json") as f:
@@ -62,8 +60,7 @@ class HiGlassWidget(ipywidgets.DOMWidget):
         self.callbacks = {}
         super().__init__(viewconf=viewconf, **kwargs)
 
-    def get_base64_img(self, callback):
-        uuid = utils.uid()
+    def get_base64_img(self, uuid, callback):
 
         self.callbacks[uuid] = callback
 

--- a/notebooks/Widget.ipynb
+++ b/notebooks/Widget.ipynb
@@ -60,32 +60,14 @@
    },
    "outputs": [],
    "source": [
-    "w.zoom_to(\"aa\", 10000, 1000000)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f5318b01",
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "f5318b01",
-    "outputId": "6548b80d-67c9-458c-9f49-fca5743ae7af"
-   },
-   "outputs": [],
-   "source": [
     "w.location"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42f046a2",
-   "metadata": {
-    "id": "42f046a2"
-   },
+   "id": "1ce53d48",
+   "metadata": {},
    "outputs": [],
    "source": []
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,8 @@
-import create from "./widget.js";
-import css from "higlass/dist/hglib.css";
+import create from './widget.js';
+import css from 'higlass/dist/hglib.css';
 
 const style = document.createElement('style');
 style.textContent = css;
 document.head.appendChild(style);
 
-define(["@jupyter-widgets/base"], create);
+define(['@jupyter-widgets/base'], create);

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1,18 +1,18 @@
 // This file is bundled by `jupyterlab extension build`
-import * as base from "@jupyter-widgets/base";
-import create from "./widget.js";
-import { name, version } from "../package.json"
+import * as base from '@jupyter-widgets/base';
+import create from './widget.js';
+import { name, version } from '../package.json';
 
 // need to import css like this because we don't have
 // control of the webpack config.
-import "higlass/dist/hglib.css";
+import 'higlass/dist/hglib.css';
 
 export default {
-	id: `${name}:plugin`,
-	requires: [base.IJupyterWidgetRegistry],
-	activate: (_app, registry) => {
-		let exports = create(base);
-		registry.registerWidget({ name, version, exports })
-	},
-	autoStart: true,
-}
+  id: `${name}:plugin`,
+  requires: [base.IJupyterWidgetRegistry],
+  activate: (_app, registry) => {
+    let exports = create(base);
+    registry.registerWidget({ name, version, exports });
+  },
+  autoStart: true,
+};


### PR DESCRIPTION
Brings in widget implementation from [`higlass-python`](https://github.com/higlass/higlass-python).

This is literally a copy and paste, and I don't really understand lots of what is going on in the implementation details. One thing I've noticed is that the `viewconf` is stateful and mutable within this implementation widget, which complicates things a quite a bit. 

The widget I'd implemented in `hg` left the viewconf fixed, and focused on APIs to interact with that instance. In fact, having a stateful viewconf within the widget allows a use of the API which is not possible because of data-flow / server setup/teardown:

```python
from higlass.client import View, Track
import higlass

t1 = Track(track_type='top-axis', position='top')
t2 = Track(track_type='heatmap', position='center',
          tileset_uuid='CQMd6V_cRw6iCI_-Unl3PQ',
          server="http://higlass.io/api/v1/",
          height=250,
          options={ 'valueScaleMax': 0.5 })

view1 = View([t1, t2], width=6)
view2 = View([t1, t2], width=6, x=6)

display, server, viewconf = higlass.display(
    [view1, view2],
    value_scale_syncs = [[(view1, t2), (view2, t2)]])

display2, server, viewconf = higlass.display(
    [view1, view2],
    value_scale_syncs = [[(view1, t2), (view2, t2)]])

display.viewconf = viewconf # allowed by the API but breaks
```

In general, I'd love to discuss what are features of the widget are most useful in practice. 